### PR TITLE
Delete routes for portfolio fixed.

### DIFF
--- a/client/src/components/Portfolio.jsx
+++ b/client/src/components/Portfolio.jsx
@@ -372,6 +372,7 @@ class Portfolio extends Component {
    */
   async handleSavePortfolio() {
     console.log("saving begins");
+    console.log(this.state.pages);
     await axios({
       method: "PUT",
       url: process.env.REACT_APP_BACKEND + "/portfolio/upsert",


### PR DESCRIPTION
### Note

- lean() can be called after a mongoose query to ensure that what is returned is not a mongoose document but a plain JS object.
- Previously, many errors were caused by extra properties in the query response, such as $__parent, $__path, $__schemaType.
- Not only so, enumerating keys from a mongoose document will not give keys that are not explicitly stated in the schema. As a result, properties that show up on console log does not show up in practice. However, object.get("example") would still get you the corresponding value, even if "example" does not show up as a key when say Object.keys(obj) is called.
- Using lean() can also improve request times and is recommended ONLY if there is no need to call save, update, delete, etc... on the queried document. i.e strictly to get a map of the objectIds of page documents.