### PR TITLE
Fixed deleteImage route

### DIFF
--- a/client/src/components/Portfolio.jsx
+++ b/client/src/components/Portfolio.jsx
@@ -497,36 +497,39 @@ class Portfolio extends Component {
     this.forceUpdate();
   }
 
+
   async handleUploadPreview() {
     console.log("uploading image");
 
     await html2canvas(document.querySelector("#preview"))
-      .then(async canvas => {
+      .then(canvas => {
 
-        const bodyFormData = new FormData();
-        bodyFormData.append('file', canvas.toDataURL("image/png"));
-        bodyFormData.append('label', "preview");
-        //console.log(bodyFormData.get("file"))
-        await axios({
-          method: "POST",
-          url: process.env.REACT_APP_BACKEND + "/portfolio/uploadImage/" + this.state.portfolio_id,
-          withCredentials: true,
-          data: bodyFormData,
-          headers: { "Content-Type": "multipart/form-data" }
-        }).then(res => {
-          console.log(res.data.message);
-        }).catch(err => {
-          if (err.response) {
-            console.log(err.response.data);
-          } else {
-            console.log(err.message);
+        canvas.toBlob(async blob => {
+            const bodyFormData = new FormData();
+            bodyFormData.append('file', new File([blob], `${this.state.name} preview`, { type: "image/png" }));
+            bodyFormData.append('label', "preview");
+            //console.log(bodyFormData.get("file"))
+            await axios({
+              method: "POST",
+              url: process.env.REACT_APP_BACKEND + "/portfolio/uploadImage/" + this.state.portfolio_id,
+              withCredentials: true,
+              data: bodyFormData,
+              headers: { "Content-Type": "multipart/form-data" }
+            }).then(res => {
+              console.log(res.data.message);
+              console.log(res.data.refs);
+            }).catch(err => {
+              if (err.response) {
+                console.log(err.response.data);
+              } else {
+                console.log(err.message);
+              }
+            })
           }
-        })
+        )
       }).catch(err => {
         console.log(err);
       })
-
-
   }
 
   // TODO: move editor components and logic into component files


### PR DESCRIPTION
### Note

- Changed to move away from valueOf() to obtain string id from objectId to using toHexString() instead.
- valueOf() is a commonly overwritten JS method and as such, even when used on the wrong object, will not lead to any errors that halt execution.
- Switching to toHexString() will reduce confusion over type comparison..
- Changed a upsertPortfolio route to be able to handle both object _id and string _id. Could be improved later to speed up processes once other functionalities are more stable.
- deleteImage route is also changed to using toHexString() and now works as intended.